### PR TITLE
Use the 2.0.2.1 folder for source_files in podspec

### DIFF
--- a/SelligentMobileSDK.podspec
+++ b/SelligentMobileSDK.podspec
@@ -12,6 +12,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios
   s.source       = { :git => "https://github.com/SelligentMarketingCloud/MobileSDK-iOS.git", :tag => "#{s.version}" }
   
-  s.source_files  = "iOS Lib 2.0.2/include"
+  s.source_files  = "iOS Lib 2.0.2.1/include"
   s.vendored_libraries = "iOS Lib 2.0.2.1/libSelligentMobile2.0.2.1.a"
 end


### PR DESCRIPTION
The source_files path was not pointing to the correct folder, breaking the cocoapod.

It might be a good idea to remove the version numbers for folders and files, or add some sort of wild cards, to avoid issues with this in the future whenever the library is updated.