### PR TITLE
Fixes Missing Reason for Privacy Manifest

### DIFF
--- a/Framework/SelligentMobileSDK.xcframework/ios-arm64/SelligentMobileSDK.framework/PrivacyInfo.xcprivacy
+++ b/Framework/SelligentMobileSDK.xcframework/ios-arm64/SelligentMobileSDK.framework/PrivacyInfo.xcprivacy
@@ -7,6 +7,10 @@
         <dict>
             <key>NSPrivacyAccessedAPIType</key>
             <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+	        <key>NSPrivacyAccessedAPITypeReasons</key>
+	        <array>
+	    	    <string>CA92.1</string>
+	        </array>
         </dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>

--- a/Framework/SelligentMobileSDK.xcframework/ios-arm64_x86_64-simulator/SelligentMobileSDK.framework/PrivacyInfo.xcprivacy
+++ b/Framework/SelligentMobileSDK.xcframework/ios-arm64_x86_64-simulator/SelligentMobileSDK.framework/PrivacyInfo.xcprivacy
@@ -7,6 +7,10 @@
         <dict>
             <key>NSPrivacyAccessedAPIType</key>
             <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+	        <key>NSPrivacyAccessedAPITypeReasons</key>
+	        <array>
+	    	    <string>CA92.1</string>
+	        </array>
         </dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>

--- a/FrameworkExtension/SelligentMobileExtensionsSDK.xcframework/ios-arm64/SelligentMobileExtensionsSDK.framework/PrivacyInfo.xcprivacy
+++ b/FrameworkExtension/SelligentMobileExtensionsSDK.xcframework/ios-arm64/SelligentMobileExtensionsSDK.framework/PrivacyInfo.xcprivacy
@@ -7,6 +7,10 @@
         <dict>
             <key>NSPrivacyAccessedAPIType</key>
             <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+	        <key>NSPrivacyAccessedAPITypeReasons</key>
+	        <array>
+	    	    <string>CA92.1</string>
+	        </array>
         </dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>

--- a/FrameworkExtension/SelligentMobileExtensionsSDK.xcframework/ios-arm64_x86_64-simulator/SelligentMobileExtensionsSDK.framework/PrivacyInfo.xcprivacy
+++ b/FrameworkExtension/SelligentMobileExtensionsSDK.xcframework/ios-arm64_x86_64-simulator/SelligentMobileExtensionsSDK.framework/PrivacyInfo.xcprivacy
@@ -7,6 +7,10 @@
         <dict>
             <key>NSPrivacyAccessedAPIType</key>
             <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+	        <key>NSPrivacyAccessedAPITypeReasons</key>
+	        <array>
+	    	    <string>CA92.1</string>
+	        </array>
         </dict>
 	</array>
 	<key>NSPrivacyCollectedDataTypes</key>


### PR DESCRIPTION
As Apple described here https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api all SDKs are obligated to include reasons for their API usages in Privacy manifest file otherwise submissions to AppStore will not be possible.